### PR TITLE
Bug fix: The process owner must be set at beginning

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -424,7 +424,7 @@ int main(int argc, char * const *argv)
 	}
 
 #ifdef HAVE_PWD_H
-	if (pw_uid > -1)
+	if (pw_uid > 0)
 	{
 		setgid(pw_gid);
 		setuid(pw_uid);


### PR DESCRIPTION
pid_t is a unsigned value