### PR TITLE
Vhost: support external files

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -161,6 +161,10 @@ static int ouistiticonfig_checkserver(serverconfig_t *new, ouistiticonfig_t *oui
 static void ouistiticonfig_servers(config_t *configfile, ouistiticonfig_t *ouistiticonfig)
 {
 	const config_setting_t *configservers = config_lookup(configfile, "servers");
+	if (configservers == NULL)
+	{
+		configservers = config_lookup(configfile, "server");
+	}
 	if (configservers)
 	{
 		int count = config_setting_length(configservers);
@@ -258,6 +262,13 @@ ouistiticonfig_t *ouistiticonfig_create(const char *filepath)
 			entry = readdir(configdir);
 		}
 		closedir(configdir);
+	}
+	else if (configd != NULL)
+	{
+		struct stat filestat;
+		int ret = stat(configd, &filestat);
+		if (!ret && S_ISREG(filestat.st_mode))
+			ouistiticonfig_subconfigfile(configd, ouistiticonfig);
 	}
 
 	return ouistiticonfig;

--- a/tests/conf/config.d/test20.vhost
+++ b/tests/conf/config.d/test20.vhost
@@ -1,0 +1,14 @@
+servers= ({
+		hostname = "myvhost3";
+		websocket = {
+			docroot = "/tmp";
+			allow = "echo";
+			deny = "*";
+			denylast = true;
+			links = ({
+				origin = "echo2";
+				destination = "echo";
+				type = "unix";
+			});
+		};
+	});

--- a/tests/conf/test20.conf.in
+++ b/tests/conf/test20.conf.in
@@ -39,7 +39,7 @@ servers= ({
                                 deny = ".htaccess,.cgi,*.php";
                                 options = "dirlisting,range";
 			};
-		});
+		},"%PWD%/tests/conf/config.d/test20.vhost");
 	});
 
 

--- a/tests/test127
+++ b/tests/test127
@@ -1,0 +1,8 @@
+DESC="test websocket startup"
+CONFIG=test20.conf
+#PREPARE_ASYNC="./utils/websocket_echo -R /tmp -u $USER -t -n echo"
+#PREPARE="./utils/websocket_echo -R /tmp -u $USER -t -D -n echo"
+#CLEAN="killall -9 websocket_echo"
+TESTOPTION="-w"
+TESTRESPONSE=test024_rs.txt
+TESTCODE=101

--- a/tests/test127_rq.txt
+++ b/tests/test127_rq.txt
@@ -1,0 +1,8 @@
+GET /echolink HTTP/1.1
+HOST: myvhost3
+Connection: Upgrade,Keep-Alive
+Upgrade: websocket
+Sec-WebSocket-Protocol: echo
+Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==
+
+Åhello


### PR DESCRIPTION
vhost config entries may be formatted as
```config
 vhost = ({
  hostname = "...
},{...}, "path/to/config/file");
```
and "path/to/config/file" may contain
```config
[server|vhost] = {
  hostname = "...
}
```
or
```config
servers = ({
 hostname = "...
});
```